### PR TITLE
Tests/numpy 2.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,10 +25,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install environment with micromamba
-      - uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: tests/test-env.yml
-          create-args: python=${{ matrix.python-version }}
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: tests/test-env.yml
+        create-args: python=${{ matrix.python-version }}
     - name: Test with pytest
       run: |
         eval "$(micromamba shell hook --shell bash)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,5 +45,5 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: matplotlib-results
+        name: matplotlib-results-${{ matrix.python-version }}
         path: tests/mpl-results/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,7 @@ jobs:
         init-shell: bash
     - name: Test with pytest
       run: |
-        micromamba activate base
+        micromamba activate pyxlma-tests
         coverage run --source=pyxlma -m pytest --mpl --mpl-baseline-path=tests/truth/images/ --mpl-generate-summary=html,json --mpl-results-path=tests/mpl-results/ tests/
         coverage xml
     - name: Upload coverage reports to Codecov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,6 +32,7 @@ jobs:
         init-shell: bash
     - name: Test with pytest
       run: |
+        eval "$(micromamba shell hook --shell bash)"
         micromamba activate pyxlma-tests
         coverage run --source=pyxlma -m pytest --mpl --mpl-baseline-path=tests/truth/images/ --mpl-generate-summary=html,json --mpl-results-path=tests/mpl-results/ tests/
         coverage xml

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python package
+name: Run pytests
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,7 @@ jobs:
       with:
         environment-file: tests/test-env.yml
         create-args: python=${{ matrix.python-version }}
+        init-shell: bash
     - name: Test with pytest
       run: |
         eval "$(micromamba shell hook --shell bash)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,6 @@ jobs:
         init-shell: bash
     - name: Test with pytest
       run: |
-        eval "$(micromamba shell hook --shell bash)"
         micromamba activate base
         coverage run --source=pyxlma -m pytest --mpl --mpl-baseline-path=tests/truth/images/ --mpl-generate-summary=html,json --mpl-results-path=tests/mpl-results/ tests/
         coverage xml

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -38,12 +38,12 @@ jobs:
         coverage run --source=pyxlma -m pytest --mpl --mpl-baseline-path=tests/truth/images/ --mpl-generate-summary=html,json --mpl-results-path=tests/mpl-results/ tests/
         coverage xml
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload matplotlib test results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: matplotlib-results
         path: tests/mpl-results/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,13 +24,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
-        eval "$(micromamba shell hook --shell bash)"
-        micromamba activate base
-        micromamba install pytest-cov pytest-mpl xarray netcdf4 pandas numpy scikit-learn scipy pyproj cartopy metpy ipywidgets python=${{ matrix.python-version }} -c conda-forge
-        python -m pip install .
+    - name: Install environment with micromamba
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: tests/test-env.yml
+          create-args: python=${{ matrix.python-version }}
     - name: Test with pytest
       run: |
         eval "$(micromamba shell hook --shell bash)"

--- a/tests/test-env.yml
+++ b/tests/test-env.yml
@@ -1,0 +1,18 @@
+name: pyxlma-tests
+channels:
+- conda-forge
+dependencies:
+- pytest-cov
+- pytest-mpl
+- xarray
+- netcdf4
+- pandas
+- numpy
+- scipy
+- scikit-learn
+- pyproj
+- metpy
+- ipywidgets
+- pip:
+  - git+https://github.com/deeplycloudy/lmatools
+  - -e .

--- a/tests/test-env.yml
+++ b/tests/test-env.yml
@@ -15,4 +15,4 @@ dependencies:
 - ipywidgets
 - pip:
   - git+https://github.com/deeplycloudy/lmatools
-  - -e .
+  - -e ../

--- a/tests/test_flash.py
+++ b/tests/test_flash.py
@@ -7,14 +7,14 @@ from pyxlma.lmalib.flash.cluster import cluster_flashes
 from pyxlma.lmalib.flash.properties import *
 
 
-def compare_dataarrays(tocheck, truth, var):
+def compare_dataarrays(tocheck, truth, var, rtol=1.e-5, atol=1.e-8):
     """Compare two dataarrays"""
     if truth[var].data.dtype == 'datetime64[ns]' or truth[var].data.dtype == 'timedelta64[ns]':
         if tocheck[var].data.dtype == 'float64':
             truth[var].data = truth[var].data.astype(float)/1e9
-        np.testing.assert_allclose(tocheck[var].data.astype(float), truth[var].data.astype(float))
+        np.testing.assert_allclose(tocheck[var].data.astype(float), truth[var].data.astype(float), rtol=rtol, atol=atol, equal_nan=True)
     else:
-        np.testing.assert_allclose(tocheck[var].data, truth[var].data)
+        np.testing.assert_allclose(tocheck[var].data, truth[var].data, rtol=rtol, atol=atol, equal_nan=True)
 
 
 def test_cluster_flashes():


### PR DESCRIPTION
Numpy appears to have changed what a percentile means with numpy 2.0, as well as maybe what it means to divide.
I added the following lines at the end of 'event_discharge_energy', right before the return statement, in pyxlma.lmalib.flash.properties

```python3
    print(zinit)
    print(-(zinit/8.4))
    print(np.exp(-(zinit/8.4)))
    print(np.percentile(z,73))
    print(np.percentile(z,27))
    print('--------')
```

I got the following results: https://www.diffchecker.com/lvlbQjU2/ (original is numpy 1.26.4, changed is 2.0.0). `-zinit/8` is reported with less precision (maybe a dtypes thing) which trickles down into `np.exp(-(zinit/8.4))` (fortunately numpy 2.0 does not change the value of Euler's number, as I had originally suspected), and same thing with the percentile values.


somehow specifying the DEFAULT VALUES `rtol` and `atol` kwargs to `np.allclose` fixes all of this? I don't understand anything anymore...